### PR TITLE
Fix for "run_for?" method

### DIFF
--- a/lib/guard/rails-assets.rb
+++ b/lib/guard/rails-assets.rb
@@ -38,7 +38,7 @@ module Guard
 
     def run_for? command
       run_on = @options[:run_on]
-      run_on = [:start, :change] if not run_on or run_on.empty? 
+      run_on = [:start, :change] if not run_on or run_on.to_s.empty?
       run_on = [run_on] unless run_on.respond_to?(:include?)
       run_on.include?(command)
     end


### PR DESCRIPTION
If run_on is a symbol, run_on.empty? will fail with a method_missing error, so change it to a string first.
