### PR TITLE
Pre-load rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,15 @@
 PATH
   remote: .
   specs:
-    guard-rails-assets (0.0.3)
+    guard-rails-assets (0.0.4)
       guard
+      rake
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
-    guard (0.4.2)
+    guard (0.5.1)
       thor (~> 0.14.6)
     rake (0.9.2)
     rspec (2.6.0)

--- a/guard-rails-assets.gemspec
+++ b/guard-rails-assets.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "guard-rails-assets"
 
   s.add_dependency             'guard'
+  s.add_dependency             'rake'
   s.add_development_dependency 'rspec'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/guard/rails-assets.rb
+++ b/lib/guard/rails-assets.rb
@@ -7,24 +7,17 @@ module Guard
     def initialize(watchers=[], options={})
       super
       @options = options || {}
-    end
-
-    def create_rails_runner
+      @run_on = @options[:run_on] || [:start, :change]
+      @run_on = [@run_on] unless @run_on.respond_to?(:include?)
       @rails_runner = RailsRunner.new
     end
 
-    def rails_runner
-      @rails_runner ||= create_rails_runner
-    end
-
     def start
-      create_rails_runner
-
       compile_assets if run_for? :start
     end
 
     def reload
-      rails_runner.restart_rails
+      @rails_runner.restart_rails
 
       compile_assets if run_for? :reload
     end
@@ -39,7 +32,7 @@ module Guard
 
     def compile_assets
       puts 'Compiling rails assets'
-      result = rails_runner.compile_assets
+      result = @rails_runner.compile_assets
 
       if result
         Notifier::notify 'Assets compiled'
@@ -49,10 +42,7 @@ module Guard
     end
 
     def run_for? command
-      run_on = @options[:run_on]
-      run_on = [:start, :change] if not run_on or run_on.to_s.empty?
-      run_on = [run_on] unless run_on.respond_to?(:include?)
-      run_on.include?(command)
+      @run_on.include?(command)
     end
   end
 end

--- a/lib/guard/rails-assets.rb
+++ b/lib/guard/rails-assets.rb
@@ -1,5 +1,6 @@
 require 'guard'
 require 'guard/guard'
+require 'rake/dsl_definition'
 
 module Guard
   class RailsAssets < Guard
@@ -8,11 +9,23 @@ module Guard
       @options = options || {}
     end
 
+    def create_rails_runner
+      @rails_runner = RailsRunner.new
+    end
+
+    def rails_runner
+      @rails_runner ||= create_rails_runner
+    end
+
     def start
+      create_rails_runner
+
       compile_assets if run_for? :start
     end
 
     def reload
+      rails_runner.restart_rails
+
       compile_assets if run_for? :reload
     end
 
@@ -26,7 +39,8 @@ module Guard
 
     def compile_assets
       puts 'Compiling rails assets'
-      result = system "bundle exec rake assets:clean assets:precompile"
+      result = rails_runner.compile_assets
+
       if result
         Notifier::notify 'Assets compiled'
       else
@@ -42,3 +56,5 @@ module Guard
     end
   end
 end
+
+require 'guard/rails-assets/rails_runner'

--- a/lib/guard/rails-assets/rails_runner.rb
+++ b/lib/guard/rails-assets/rails_runner.rb
@@ -1,6 +1,5 @@
 module Guard
-  
-  # Keeps rails loaded in a thread waiting to run the asset pipeline compiler
+
   class RailsAssets::RailsRunner
 
     def initialize
@@ -29,6 +28,10 @@ module Guard
       end
     end
 
+    def boot_rails
+      require "#{Dir.pwd}/config/environment.rb"
+    end
+
     def run_compiler
       begin
         @failed = false
@@ -38,10 +41,6 @@ module Guard
         puts "An error occurred compiling assets: #{e}"
         @failed = true
       end
-    end
-
-    def boot_rails
-      require "#{Dir.pwd}/config/environment.rb"
     end
 
     # Runs the asset pipeline compiler.

--- a/lib/guard/rails-assets/rails_runner.rb
+++ b/lib/guard/rails-assets/rails_runner.rb
@@ -1,0 +1,64 @@
+module Guard
+  
+  # Keeps rails loaded in a thread waiting to run the asset pipeline compiler
+  class RailsAssets::RailsRunner
+
+    def initialize
+      boot_rails
+    end
+
+    # Methods to run the asset pipeline
+    # Taken from - https://github.com/rails/rails/blob/master/actionpack/lib/sprockets/assets.rake
+    module AssetPipeline
+      extend self
+      extend Rake::DSL
+      
+      def clean
+        assets = Rails.application.config.assets
+        public_asset_path = Rails.public_path + assets.prefix
+        rm_rf public_asset_path, :secure => true
+      end
+
+      def precompile
+        Sprockets::Helpers::RailsHelper
+
+        assets = Rails.application.config.assets.precompile
+        # Always perform caching so that asset_path appends the timestamps to file references.
+        Rails.application.config.action_controller.perform_caching = true
+        Rails.application.assets.precompile(*assets)
+      end
+    end
+
+    def run_compiler
+      begin
+        @failed = false
+        AssetPipeline.clean
+        AssetPipeline.precompile
+      rescue => e
+        puts "An error occurred compiling assets: #{e}"
+        @failed = true
+      end
+    end
+
+    def boot_rails
+      require "#{Dir.pwd}/config/environment.rb"
+    end
+
+    # Runs the asset pipeline compiler.
+    #
+    # @return [ Boolean ] Whether the compilation was successful or not
+    def compile_assets
+      run_compiler
+      
+      !failed?
+    end
+
+    def failed?
+      @failed
+    end
+
+    def restart_rails
+      fail "Not implemented"
+    end
+  end
+end

--- a/spec/guard/rails-assets/rails_runner_spec.rb
+++ b/spec/guard/rails-assets/rails_runner_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Guard::RailsAssets::RailsRunner do
+  
+  describe ".compile_assets" do
+    
+    let(:asset_pipeline) { Guard::RailsAssets::RailsRunner::AssetPipeline }
+    
+    before do
+      described_class.class_eval do
+        def boot_rails
+        end
+      end
+    end
+    
+    context "successful compile" do
+      before do
+        asset_pipeline.stub(:clean)
+        asset_pipeline.stub(:precompile)
+      end
+      
+      it "clean's the assets" do
+        asset_pipeline.should_receive(:clean)
+        subject.compile_assets
+      end
+      
+      it "runs the compiler" do
+        asset_pipeline.should_receive(:precompile)
+        subject.compile_assets
+      end
+      
+      it "returns true" do
+        subject.compile_assets.should be_true
+      end
+    end
+    
+    context "with a compilation error" do
+      
+      before do
+        asset_pipeline.stub(:clean)
+        asset_pipeline.should_receive(:precompile).and_raise(StandardError)
+        @output = capture(:stdout) do
+          @result = subject.compile_assets
+        end
+      end
+      
+      it "outputs the error" do
+        @output.should include("An error occurred")
+      end
+      
+      it "returns false" do
+        @result.should be_false
+      end
+      
+      context "on next successful compile" do
+        
+        it "works" do
+          asset_pipeline.should_receive(:clean)
+          asset_pipeline.should_receive(:precompile)
+          subject.compile_assets.should be_true
+        end
+        
+      end
+      
+    end
+    
+  end
+  
+end

--- a/spec/guard/rails-assets_spec.rb
+++ b/spec/guard/rails-assets_spec.rb
@@ -3,12 +3,12 @@ require 'guard/rails-assets'
 
 describe Guard::RailsAssets do
   let(:options) { {} }
-  let(:rails_thread) { mock(Guard::RailsAssets::RailsThread) }
+  let(:rails_runner) { mock(Guard::RailsAssets::RailsRunner) }
   subject { Guard::RailsAssets.new(['watchers'], options) }
 
   before do
-    Guard::RailsAssets::RailsThread.stub(:new => rails_thread)
-    rails_thread.stub(:compile_assets => true, :restart_rails => true)
+    Guard::RailsAssets::RailsRunner.stub(:new => rails_runner)
+    rails_runner.stub(:compile_assets => true, :restart_rails => true)
   end
 
   describe '#start' do
@@ -43,7 +43,7 @@ describe Guard::RailsAssets do
 
   describe 'asset compilation using CLI' do
     def stub_system_with result
-      rails_thread.should_receive(:compile_assets).and_return result
+      rails_runner.should_receive(:compile_assets).and_return result
     end
 
     it 'should notify on success' do

--- a/spec/guard/rails-assets_spec.rb
+++ b/spec/guard/rails-assets_spec.rb
@@ -3,7 +3,13 @@ require 'guard/rails-assets'
 
 describe Guard::RailsAssets do
   let(:options) { {} }
+  let(:rails_thread) { mock(Guard::RailsAssets::RailsThread) }
   subject { Guard::RailsAssets.new(['watchers'], options) }
+
+  before do
+    Guard::RailsAssets::RailsThread.stub(:new => rails_thread)
+    rails_thread.stub(:compile_assets => true, :restart_rails => true)
+  end
 
   describe '#start' do
     it_behaves_like 'guard command', :command => :start,         :run => true
@@ -37,7 +43,7 @@ describe Guard::RailsAssets do
 
   describe 'asset compilation using CLI' do
     def stub_system_with result
-      subject.should_receive(:system).with("bundle exec rake assets:clean assets:precompile").and_return result
+      rails_thread.should_receive(:compile_assets).and_return result
     end
 
     it 'should notify on success' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec'
 require 'guard/rails-assets'
 require 'support/shared_examples'
+require 'support/stdout_helper'
 
 RSpec.configure do |config|
   config.color_enabled = true
@@ -15,5 +16,7 @@ RSpec.configure do |config|
   config.after(:each) do
     ENV["GUARD_ENV"] = nil
   end
+  
+  config.include(Helpers)
 
 end

--- a/spec/support/stdout_helper.rb
+++ b/spec/support/stdout_helper.rb
@@ -1,0 +1,17 @@
+require 'stringio'
+
+module Helpers
+  
+  def capture(*streams)
+    streams.map! { |stream| stream.to_s }
+    begin
+      result = StringIO.new
+      streams.each { |stream| eval "$#{stream} = result" }
+      yield
+    ensure
+      streams.each { |stream| eval("$#{stream} = #{stream.upcase}") }
+    end
+    result.string
+  end
+  
+end


### PR DESCRIPTION
This patch pre-loads the rails environment so that running the asset pipeline doesn't have the delay of loading rails. Bunder should handle and dependency issues, so best to run with `bundle exec guard`.

Reloading, or ctrl + z in guard isn't implemented. Unless anyone can think of a reliable way to unload rails, that's probably only possible with implementations that manage rails in a separate process (spork).
