### PR TITLE
Add configuration options to rails runner so that it can be used in non-rails environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Also you can set the `:runner` option:
 - `:cli` - compile assets using the rake task - the most correct method, but slow.
 - `:rails` - compile assets by loading rails environment (default) - fast, but does not pick up changes.
 
+If you're using sprockets standalone or with sinatra, you can override the rails
+runners sprockets environment and environment_path with your custom settings.
+
+- `:sprockets_environment` - a lambda that returns an instance of Sprockets::Environment. E.g. `lambda { App.sprockets }`
+- `:environment_path` - defaults to "config/environment.rb"
+- `:precompile` - an array of assets to precompile. Required if you're not using Rails. E.g. `["*"]`
 
 
 For example:
@@ -73,6 +79,12 @@ end
 # compile when something changes and when starting
 guard 'rails-assets', :run_on => [:start, :change] do
   watch(%r{^app/assets/.+$})
+end
+
+# Non-rails configuration
+guard 'rails-assets', :sprockets_environment => lambda { App.sprockets }, :environment_path => "app.rb", :precompile => ["*"] do
+  watch(%r{^app/assets/.+$})
+  watch('app.rb')
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ guard init rails-assets
 
 ## Rails 3.1
 
-The Rails 3.1 is a mandatory requirement, but is not enforeced via dependencies for now.
+The Rails 3.1 is a mandatory requirement, but is not enforced via dependencies for now.
 The reason is that the assets can currently be compiled using following "runners":
 
 1. rake command (CLI);
@@ -42,7 +42,7 @@ The 2nd approach is good because it is much faster, but does not reload Rails en
 
 ## Guardfile and Options
 
-In addition to the standard configuration, this Guard has options to specify when exacly to precompile assets.
+In addition to the standard configuration, this Guard has options to specify when exactly to precompile assets.
 
 - `:start` - compile assets when the guard starts (enabled by default)
 - `:change` - compile assets when watched files change (enabled by default)

--- a/spec/guard/rails-assets/rails_runner_spec.rb
+++ b/spec/guard/rails-assets/rails_runner_spec.rb
@@ -2,17 +2,19 @@ require 'spec_helper'
 
 describe Guard::RailsAssets::RailsRunner do
 
-  subject { Guard::RailsAssets::RailsRunner.new({}) }
+  let(:sprockets) { mock }
+  subject { Guard::RailsAssets::RailsRunner.new({:sprockets_environment => lambda { sprockets }}) }
   
   describe ".compile_assets" do
     
-    let(:asset_pipeline) { Guard::RailsAssets::RailsRunner::AssetPipeline }
+    let(:asset_pipeline) { mock(Guard::RailsAssets::RailsRunner::AssetPipeline) }
     
     before do
       described_class.class_eval do
         def boot_rails
         end
       end
+      Guard::RailsAssets::RailsRunner::AssetPipeline.stub(:new => asset_pipeline)
     end
     
     context "successful compile" do


### PR DESCRIPTION
I'm using sprockets with sinatra, and I'd rather not have to monkey patch this gem to make it work.

https://github.com/stevehodgkiss/sinatra-asset-pipeline/blob/master/Guardfile

With this patch the file could be:

``` ruby
guard 'rails-assets', :sprockets_environment => lambda { App.sprockets }, :environment_path => "app.rb", :precompile => ["*"] do
  watch(%r{^app/assets/.+$})
  watch('app.rb')
end
```

Let me know what you think.

Thanks!
