### PR TITLE
Fixes circular dependency check failures

### DIFF
--- a/lib/guard/rails-assets/rails_runner.rb
+++ b/lib/guard/rails-assets/rails_runner.rb
@@ -47,11 +47,24 @@ module Guard
       return false unless @@rails_booted
       begin
         Rake::Task['assets:clean'].execute
+        clear_cached_assets_dependencies
         Rake::Task['assets:precompile'].execute
         true
       rescue => e
         puts "An error occurred compiling assets: #{e}"
         false
+      end
+    end
+  protected
+    # Purges cached assets dependencies, as their circular dependency
+    # checking fails because it's never cleared by rails.
+    #
+    # @return nothing.
+    def clear_cached_assets_dependencies
+      cached_assets = ::Rails.application.assets.instance_variable_get(:@assets)
+      cached_assets.each do |path, cached_asset|
+        options = cached_asset.instance_variable_get(:@options)
+        options[:_requires] = []
       end
     end
   end


### PR DESCRIPTION
Previously, if you used the rails runner to prevent reloading the rails
server and you attempted to build the same bundled asset twice,
sprockets would fail with a circular dependency check error.

It turns out that sprockets caches bundled assets in memory and doesn't
clear it's circular dependency checking array, this commit goes in and
clears that array to prevent that check from failing.
