### PR TITLE
Fixing asset precompiling in cli runner

### DIFF
--- a/lib/guard/rails-assets/cli_runner.rb
+++ b/lib/guard/rails-assets/cli_runner.rb
@@ -9,7 +9,7 @@ module Guard
     def compile_assets
       task = "assets:precompile"
       task += ":nondigest" unless @digest
-      system "RAILS_ENV=#{@rails_env} bundle exec rake assets:clean #{task}"
+      system "bundle exec rake assets:clean #{task} RAILS_ENV=#{@rails_env}"
     end
   end
 end


### PR DESCRIPTION
Moved the RAILS_ENV setting to the end. Otherwise the call returned nil and no asset precompiling was initiated.
