### PR TITLE
Fix resolving of Rails constant so it plays nice with Guard::Rails

### DIFF
--- a/lib/guard/rails-assets/rails_runner.rb
+++ b/lib/guard/rails-assets/rails_runner.rb
@@ -40,12 +40,12 @@ module Guard
       Rake::Task["tmp:cache:clear"].execute
       # copy from the "assets:clean" Rake task
       config = ::Rails.application.config
-      public_asset_path = File.join(Rails.public_path, config.assets.prefix)
+      public_asset_path = File.join(::Rails.public_path, config.assets.prefix)
       rm_rf public_asset_path, :secure => true
     end
 
     def precompile
-      config = Rails.application.config
+      config = ::Rails.application.config
       unless config.assets.enabled
         warn "Cannot precompile assets if sprockets is disabled. Enabling it."
         config.assets.enabled = true
@@ -61,8 +61,8 @@ module Guard
       config.assets.digest  = digest
       config.assets.digests = {}
 
-      env      = Rails.application.assets
-      target   = File.join(Rails.public_path, config.assets.prefix)
+      env      = ::Rails.application.assets
+      target   = File.join(::Rails.public_path, config.assets.prefix)
       compiler = Sprockets::StaticCompiler.new(env,
                                                target,
                                                config.assets.precompile,

--- a/spec/guard/rails-assets/cli_runner_spec.rb
+++ b/spec/guard/rails-assets/cli_runner_spec.rb
@@ -4,7 +4,7 @@ describe Guard::RailsAssets::CliRunner do
 
   it 'should run the command' do
     subject.stub(:system)
-    subject.should_receive(:system).with("RAILS_ENV=test bundle exec rake assets:clean assets:precompile")
+    subject.should_receive(:system).with("bundle exec rake assets:clean assets:precompile RAILS_ENV=test")
     subject.compile_assets
   end
 
@@ -12,7 +12,7 @@ describe Guard::RailsAssets::CliRunner do
     subject { Guard::RailsAssets::CliRunner.new(:rails_env => :production) }
     it 'should run the command' do
       subject.stub(:system)
-      subject.should_receive(:system).with("RAILS_ENV=production bundle exec rake assets:clean assets:precompile")
+      subject.should_receive(:system).with("bundle exec rake assets:clean assets:precompile RAILS_ENV=production")
       subject.compile_assets
     end
   end


### PR DESCRIPTION
Was running guard-rails-assets in the same group as guard-rails and guard-rails-assets was not getting the right Rails constant. This fix ensures the right Rails constant is located for use.

Also, fixed an unrelated failing test.
